### PR TITLE
added mouseover text-accent support like in vanilla

### DIFF
--- a/cohostThemeCustomizer.user.css
+++ b/cohostThemeCustomizer.user.css
@@ -427,7 +427,11 @@
         /* edit profile 'buttons' */
         color: var(--color-prose-100);
     }
-
+    
+    .hover\:text-accent:hover {
+        color: var(--color-accent)
+    }
+    
     .hover\:bg-accent:hover {
         background-color: var(--color-accent);
     }

--- a/cohostThemeCustomizer.user.css
+++ b/cohostThemeCustomizer.user.css
@@ -3,7 +3,7 @@
 @description  Customizable theme for cohost
 @namespace    cohost.org/kiophen
 @author       kiophen
-@version      3.1.4
+@version      3.1.5
 @license      MIT
 @preprocessor less
 @updateURL    https://github.com/warpKaiba/cohost-theme-customizer/raw/main/cohostThemeCustomizer.user.css

--- a/cohostThemeCustomizer.user.css
+++ b/cohostThemeCustomizer.user.css
@@ -429,7 +429,7 @@
     }
     
     .hover\:text-accent:hover {
-        color: var(--color-accent)
+        color: var(--color-accent);
     }
     
     .hover\:bg-accent:hover {


### PR DESCRIPTION
Currently, cohost's vanilla theming supports switching to an accent color on mouseover. It felt like an oversight not to have that here. 